### PR TITLE
use OSM's SMP compliant name in install operation

### DIFF
--- a/internal/config/operations.go
+++ b/internal/config/operations.go
@@ -15,12 +15,15 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/meshes"
+	smp "github.com/layer5io/service-mesh-performance/spec"
 )
 
 var (
-	OSMOperation          = "osm"
+	OSMOperation          = strings.ToLower(smp.ServiceMesh_OPEN_SERVICE_MESH.Enum().String())
 	OSMBookStoreOperation = "osm_bookstore_app"
 	ServiceName           = "service_name"
 )


### PR DESCRIPTION
**Description**
Sets install operation to [open_service_mesh](https://github.com/service-mesh-performance/service-mesh-performance/blob/8a9355043b1b708f7f194dc50367bf68695fb7a2/spec/service_mesh.pb.go#L41) so as to enforce uniformity across various methods of deployments.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
