### PR TITLE
[lifecycle] use helm chart version instead of appVersion for installing

### DIFF
--- a/osm/install.go
+++ b/osm/install.go
@@ -61,7 +61,7 @@ func (h *Handler) applyHelmChart(del bool, version, namespace string) error {
 		ChartLocation: mesherykube.HelmChartLocation{
 			Repository: repo,
 			Chart:      chart,
-			AppVersion: version,
+			Version: version,
 		},
 		Namespace:       namespace,
 		Delete:          del,


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes #

**Notes for Reviewers**
* This should be ideally removed in the future when osm fixes their helm chart as `appVersion` corresponds to the service mesh version. But doing this for now to fix broken OSM installation.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
