### PR TITLE
move to thread-safe viper

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/layer5io/meshery-adapter-library/common"
 	"github.com/layer5io/meshery-adapter-library/config"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
 	"github.com/layer5io/meshery-adapter-library/status"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshkit/utils"
 	smp "github.com/layer5io/service-mesh-performance/spec"
 )
@@ -50,10 +50,9 @@ var (
 
 func New(provider string) (config.Handler, error) {
 	opts := configprovider.Options{
-		ServerConfig:   ServerDefaults,
-		MeshSpec:       MeshSpecDefaults,
-		ProviderConfig: ProviderConfigDefaults,
-		Operations:     OperationsDefaults,
+		FilePath: configRootPath,
+		FileName: "osm",
+		FileType: "yaml",
 	}
 	switch provider {
 	case configprovider.ViperKey:
@@ -66,10 +65,11 @@ func New(provider string) (config.Handler, error) {
 
 func NewKubeconfigBuilder(provider string) (config.Handler, error) {
 
-	opts := configprovider.Options{}
-
-	// Config environment
-	opts.ProviderConfig = KubeConfigDefaults
+	opts := configprovider.Options{
+		FilePath: configRootPath,
+		FileType: "yaml",
+		FileName: "kubeconfig",
+	}
 
 	// Config provider
 	switch provider {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"path"
 
+	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/common"
 	"github.com/layer5io/meshery-adapter-library/config"
 	"github.com/layer5io/meshery-adapter-library/status"
@@ -24,13 +25,13 @@ var (
 		"name":     smp.ServiceMesh_OPEN_SERVICE_MESH.Enum().String(),
 		"type":     "adapter",
 		"port":     "10009",
-		"traceurl": "none",
+		"traceurl": status.None,
 	}
 
 	MeshSpecDefaults = map[string]string{
 		"name":    smp.ServiceMesh_OPEN_SERVICE_MESH.Enum().String(),
 		"status":  status.NotInstalled,
-		"version": "none",
+		"version": status.None,
 	}
 
 	ProviderConfigDefaults = map[string]string{
@@ -48,7 +49,7 @@ var (
 	OperationsDefaults = getOperations(common.Operations)
 )
 
-func New(provider string) (config.Handler, error) {
+func New(provider string) (h config.Handler, err error) {
 	opts := configprovider.Options{
 		FilePath: configRootPath,
 		FileName: "osm",
@@ -56,11 +57,34 @@ func New(provider string) (config.Handler, error) {
 	}
 	switch provider {
 	case configprovider.ViperKey:
-		return configprovider.NewViper(opts)
+		h, err = configprovider.NewViper(opts)
+		if err != nil {
+			return nil, err
+		}
 	case configprovider.InMemKey:
-		return configprovider.NewInMem(opts)
+		h, err = configprovider.NewInMem(opts)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrEmptyConfig
 	}
-	return nil, config.ErrEmptyConfig
+	// Setup server config
+	if err := h.SetObject(adapter.ServerKey, ServerDefaults); err != nil {
+		return nil, err
+	}
+
+	// Setup mesh config
+	if err := h.SetObject(adapter.MeshSpecKey, MeshSpecDefaults); err != nil {
+		return nil, err
+	}
+
+	// Setup Operations Config
+	if err := h.SetObject(adapter.OperationsKey, OperationsDefaults); err != nil {
+		return nil, err
+	}
+
+	return h, nil
 }
 
 func NewKubeconfigBuilder(provider string) (config.Handler, error) {

--- a/main.go
+++ b/main.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/api/grpc"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
 	internalconfig "github.com/layer5io/meshery-osm/internal/config"
 	"github.com/layer5io/meshery-osm/osm"
 	"github.com/layer5io/meshery-osm/osm/oam"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshkit/logger"
 	"github.com/layer5io/meshkit/utils"
 )

--- a/osm/osm.go
+++ b/osm/osm.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
-	"github.com/layer5io/meshery-adapter-library/config"
 	"github.com/layer5io/meshery-osm/osm/oam"
+	meshkitCfg "github.com/layer5io/meshkit/config"
 	"github.com/layer5io/meshkit/logger"
 	"github.com/layer5io/meshkit/models/oam/core/v1alpha1"
 )
@@ -30,7 +30,7 @@ type Handler struct {
 }
 
 // New initializes a new handler instance
-func New(config config.Handler, log logger.Handler, kc config.Handler) adapter.Handler {
+func New(config meshkitCfg.Handler, log logger.Handler, kc meshkitCfg.Handler) adapter.Handler {
 	return &Handler{
 		Adapter: adapter.Adapter{
 			Config:            config,


### PR DESCRIPTION
Signed-off-by: sayantan1413 <sayantanbose2001@gmail.com>

**Description**

Operations are now thread safe. This has been done by replacing meshery-adapter-library config provider implementation with meshkit config provider implementation which share similar interfaces.

This PR fixes #106 

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
