### PR TITLE
[Bug] Incorporate Adapter Version # at buildtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 	"github.com/layer5io/meshkit/utils"
 )
 
-const (
+var (
 	serviceName = "osm-adapter"
 	version     = "none"
 	gitsha      = "none"


### PR DESCRIPTION
Signed-off-by: Michael Gfeller <mgfeller@mgfeller.net>

**Description**

The build-args main.version=$VERSION and main.gitsha=$GIT_COMMITSHA were not being set in the code, this is fixed now.

This PR fixes #111 

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
