### PR TITLE
[CI] fix creation of commits in error codes utility workflow

### DIFF
--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -60,5 +60,5 @@ jobs:
           commit_user_email: ci@layer5.io
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit_options: '--signoff'
-          commit_message: '[Docs] Error Code Reference: Updated codes for OSM adapter'
+          commit_message: '[Docs] Error Code Reference: Meshery Adapter for OSM updated'
           file_pattern: docs/

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -36,7 +36,7 @@ jobs:
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit_options: '--signoff'
           commit_message: "run error codes utility"
-          file_pattern: helpers/ **.go
+          file_pattern: helpers/ **/error.go
 
       # to push changes to meshery docs
       - name: Checkout meshery
@@ -48,18 +48,17 @@ jobs:
           path: 'meshery'
           ref: 'master'
 
-      - name: Update and push docs
+      - name: Update docs
         run: |
           echo '{ "errors_export": "" }' | jq --slurpfile export ./helpers/errorutil_errors_export.json '.errors_export = $export[0]' > ./meshery/docs/_data/errorref/osm_errors_export.json
-          cd ./meshery
-          git config user.name l5io
-          git config user.email ci@layer5.io
-          if git diff --exit-code --quiet
-          then
-            echo "No changes to commit"
-            exit
-          fi
-          git add ./docs/_data/errorref/osm_errors_export.json
-          git commit -m "[Docs] Error Code Reference: Updated codes for OSM adapter " --signoff
-          git push origin master
-          
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          repository: ./meshery
+          commit_user_name: l5io
+          commit_user_email: ci@layer5.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          commit_options: '--signoff'
+          commit_message: '[Docs] Error Code Reference: Updated codes for OSM adapter'
+          file_pattern: docs/

--- a/helpers/component_info.json
+++ b/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "osm",
   "type": "adapter",
-  "next_error_code": 1034
+  "next_error_code": 1020
 }


### PR DESCRIPTION
Signed-off-by: Suryashankar Das <suryashankardas.2002@gmail.com>

**Description**

This PR fixes the creation of commits in the meshery repo using the error codes utility workflow
Related to [this](https://github.com/meshery/meshery-istio/issues/267) issue

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
