### PR TITLE
[Build] move to kubeopenapi-jsonschema compatible base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: ${{ secrets.GO_VERSION }}
-      - run: GOPROXY=direct GOSUMDB=off go get -u golang.org/x/lint/golint; go list ./osm/... | grep -v /vendor/ | xargs -L1 /home/runner/go/bin/golint -set_exit_status
+      - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off go get -u golang.org/x/lint/golint; go list ./osm/... | grep -v /vendor/ | xargs -L1 /home/runner/go/bin/golint -set_exit_status
   error_check:
     name: Error check
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: ${{ secrets.GO_VERSION }}
-      - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck -tags draft ./...
+      - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck -tags draft ./...
   static_check:
     name: Static check
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: ${{ secrets.GO_VERSION }}
-      - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; /home/runner/go/bin/staticcheck -tags draft -checks all ./osm/... # https://staticcheck.io/docs/checks
+      - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; /home/runner/go/bin/staticcheck -tags draft -checks all ./osm/... # https://staticcheck.io/docs/checks
   vet:
     name: Vet
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: ${{ secrets.GO_VERSION }}
-      - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go vet -tags draft ./...
+      - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go vet -tags draft ./...
   sec_check:
     name: Security check
     runs-on: ubuntu-latest
@@ -99,4 +99,4 @@ jobs:
          echo "current-context:" ${CURRENTCONTEXT}   
          export KUBECONFIG="${HOME}/.kube/config"
          echo "environment-kubeconfig:" ${KUBECONFIG}
-         GOPROXY=direct GOSUMDB=off GO111MODULE=on go test ./...
+         GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ COPY internal/ internal/
 COPY osm/ osm/
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-osm main.go
 
-FROM gcr.io/distroless/base
+FROM alpine:3.14 as jsonschema-util
+RUN apk add --no-cache curl
+WORKDIR /
+RUN curl -LO https://github.com/layer5io/kubeopenapi-jsonschema/releases/download/v0.1.0/kubeopenapi-jsonschema
+
+FROM gcr.io/distroless/nodejs:14
 ENV DISTRO="debian"
 ENV GOARCH="amd64"
 ENV SERVICE_ADDR="meshery-osm"
@@ -17,4 +22,5 @@ ENV MESHERY_SERVER="http://meshery:9081"
 WORKDIR /
 COPY templates/ ./templates
 COPY --from=build-env /github.com/layer5io/meshery-osm/meshery-osm .
+COPY --from=jsonschema-util /kubeopenapi-jsonschema /root/.meshery/bin/kubeopenapi-jsonschema
 ENTRYPOINT ["/meshery-osm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY main.go main.go
 COPY internal/ internal/
 COPY osm/ osm/
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-osm main.go
+RUN GOPROXY=https://proxy.golang.org,direct CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-osm main.go
 
 FROM alpine:3.14 as jsonschema-util
 RUN apk add --no-cache curl

--- a/helpers/component_info.json
+++ b/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "osm",
   "type": "adapter",
-  "next_error_code": 1023
+  "next_error_code": 1021
 }


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes #

**Notes for Reviewers**
Moves to a nodejs based distroless image and fetches kubeopenapi-jsonschema util at buildtime.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
