### PR TITLE
[chore] Normalised Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOPATH = $(shell go env GOPATH)
 
 ## Run Meshery Adapter.
 run:
-	go mod tidy; \
+	go mod tidy -compat=1.17; \
 	DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
 
 run-force-dynamic-reg:

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -1,0 +1,50 @@
+# Copyright Meshery Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------------
+# Global Variables
+#-----------------------------------------------------------------------------
+GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
+GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
+GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
+
+GOVERSION = 1.17.8
+GOPATH = $(shell go env GOPATH)
+GOBIN  = $(GOPATH)/bin
+
+SHELL :=/bin/bash -o pipefail
+
+#-----------------------------------------------------------------------------
+# Components
+#-----------------------------------------------------------------------------
+ADAPTER_URLS := "localhost:10000 localhost:10001 localhost:10002 localhost:10004 localhost:10005 localhost:10006 localhost:10007 localhost:10009 localhost:10010 localhost:10012"
+
+#-----------------------------------------------------------------------------
+# Providers
+#-----------------------------------------------------------------------------
+REMOTE_PROVIDER_LOCAL="http://localhost:9876"
+MESHERY_CLOUD_DEV="http://localhost:9876"
+MESHERY_CLOUD_PROD="https://meshery.layer5.io"
+MESHERY_CLOUD_STAGING="https://staging-meshery.layer5.io"
+
+#-----------------------------------------------------------------------------
+# Server
+#-----------------------------------------------------------------------------
+MESHERY_K8S_SKIP_COMP_GEN ?= TRUE
+APPLICATIONCONFIGPATH="../install/apps.json"
+
+#-----------------------------------------------------------------------------
+# Build
+#-----------------------------------------------------------------------------
+RELEASE_CHANNEL=edge


### PR DESCRIPTION
**Description**

While running this adapter locally through `make run` I was seeing following warnings:
```
➜  meshery-osm git:(master) make run
go mod tidy; \
	DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/internal loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/matchers loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/types loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/matchers imports
	github.com/onsi/gomega/format loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/matchers imports
	github.com/onsi/gomega/matchers/support/goraph/bipartitegraph loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/matchers imports
	github.com/onsi/gomega/matchers/support/goraph/bipartitegraph imports
	github.com/onsi/gomega/matchers/support/goraph/edge loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/matchers imports
	github.com/onsi/gomega/matchers/support/goraph/bipartitegraph imports
	github.com/onsi/gomega/matchers/support/goraph/node loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0
github.com/layer5io/meshery-osm/osm imports
	github.com/layer5io/meshkit/utils/kubernetes imports
	helm.sh/helm/v3/pkg/action imports
	helm.sh/helm/v3/pkg/kube imports
	k8s.io/apimachinery/pkg/util/strategicpatch imports
	k8s.io/kube-openapi/pkg/util/proto tested by
	k8s.io/kube-openapi/pkg/util/proto.test imports
	github.com/onsi/gomega imports
	github.com/onsi/gomega/matchers imports
	github.com/onsi/gomega/matchers/support/goraph/bipartitegraph imports
	github.com/onsi/gomega/matchers/support/goraph/util loaded from github.com/onsi/gomega@v1.15.0,
	but go 1.16 would select v1.17.0

To upgrade to the versions selected by go 1.16:
	go mod tidy -go=1.16 && go mod tidy -go=1.17
If reproducibility with go 1.16 is not needed:
	go mod tidy -compat=1.17
For other options, see:
	https://golang.org/doc/modules/pruning
INFO[2022-08-03T21:43:02+05:30] Adapter listening on port: 10009              app=osm-adapter
INFO[2022-08-03T21:43:02+05:30] Components available statically for version v1.2.0. Skipping dynamic component registeration  app=osm-adapter
```

So, I've updated the Makefile to fix this. Also, updated the rest of file with what we are using across other repos.

This PR fixes #

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
